### PR TITLE
sets miner.threads to 1 when running geth.

### DIFF
--- a/bbc1/core/ethereum/bbc_ethereum.py
+++ b/bbc1/core/ethereum/bbc_ethereum.py
@@ -304,6 +304,7 @@ def setup_run(bbcConfig):
         '--nodiscover',
         '--etherbase', config['ethereum']['account'],
         '--mine',
+        '--miner.threads', '1',
     ], stderr=log)
 
     config['ethereum']['pid'] = proc.pid

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ bbc1_classifiers = [
 
 setup(
     name='ledger_subsystem',
-    version='0.11.0',
+    version='0.11.1',
     description='A ledger subsystem of Beyond Blockchain One',
     long_description=readme,
     url='https://github.com/beyond-blockchain/ledger_subsystem',


### PR DESCRIPTION
A recent change made to geth may have disabled eth_subsystem_tool.py to run the process with mining, because now by default the number of mining threads is set to zero.

This change specifies that miner.threads = 1 upon running geth so that mining can proceed.
