### PR TITLE
Fix for a verification-only use

### DIFF
--- a/bbc1/core/ethereum/bbc_ethereum.py
+++ b/bbc1/core/ethereum/bbc_ethereum.py
@@ -221,7 +221,7 @@ class BBcEthereum:
         else:
             project.BBcAnchor.at(contract_address)
 
-        self.account = accounts[0]
+        self.account = None if len(accounts) <= 0 else accounts[0]
         self.anchor = project.BBcAnchor[0]
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ bbc1_classifiers = [
 
 setup(
     name='ledger_subsystem',
-    version='0.13',
+    version='0.13.1',
     description='A ledger subsystem of Beyond Blockchain One',
     long_description=readme,
     url='https://github.com/beyond-blockchain/ledger_subsystem',

--- a/utils/eth_subsystem_tool.py
+++ b/utils/eth_subsystem_tool.py
@@ -43,7 +43,7 @@ class EthereumSubsystemTool(subsystem_tool_lib.SubsystemTool):
         super().__init__(
             name='Ethereum',
             tool='eth_subsystem_tool.py',
-            version='0.13.0'
+            version='0.13.1'
         )
 
 

--- a/utils/eth_subsystem_tool.py
+++ b/utils/eth_subsystem_tool.py
@@ -43,7 +43,7 @@ class EthereumSubsystemTool(subsystem_tool_lib.SubsystemTool):
         super().__init__(
             name='Ethereum',
             tool='eth_subsystem_tool.py',
-            version='0.12.0'
+            version='0.13.0'
         )
 
 


### PR DESCRIPTION
A BBcEthereum object can now be created without a private key for verification-only use.