### PR TITLE
Fixed a problem for specifying and using an existing anchor contract.

### DIFF
--- a/bbc1/core/ethereum/bbc_ethereum.py
+++ b/bbc1/core/ethereum/bbc_ethereum.py
@@ -175,6 +175,30 @@ def setup_deploy(bbcConfig):
     os.chdir(prevdir)
 
 
+def setup_deployed(bbcConfig, new_contract_address):
+    """Use deployed BBcAnchor contract at Ethereum ledger subsystem.
+
+    Args:
+        bbcConfig (BBcConfig): The configuration object.
+        new_contract_address (str): The contract address to use.
+
+    """
+
+    prevdir = chdir_to_this_filepath()
+
+    config = bbcConfig.get_config()
+
+    contract_address = config['ethereum']['contract_address']
+    if contract_address != '':
+        config['ethereum']['previous_contract_address'] = contract_address
+
+    config['ethereum']['contract_address'] = new_contract_address
+
+    os.chdir('..')
+    bbcConfig.update_config()
+    os.chdir(prevdir)
+
+
 def setup_new_account(bbcConfig):
     """Creates a new Ethereum account to be used in the ledger subsystem.
 
@@ -239,11 +263,12 @@ class BBcEthereum:
 
         if contract_address is None:
             accounts[0].deploy(project.EthereumProject.BBcAnchor)
+            self.anchor = project.EthereumProject.BBcAnchor[0]
         else:
-            project.EthereumProject.BBcAnchor.at(contract_address)
+            self.anchor = project.EthereumProject.BBcAnchor.at(
+                    contract_address)
 
         self.account = None if len(accounts) <= 0 else accounts[0]
-        self.anchor = project.EthereumProject.BBcAnchor[0]
 
 
     def blockingSet(self, digest):

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ bbc1_classifiers = [
 
 setup(
     name='ledger_subsystem',
-    version='0.14.1',
+    version='0.15',
     description='A ledger subsystem of Beyond Blockchain One',
     long_description=readme,
     url='https://github.com/beyond-blockchain/ledger_subsystem',

--- a/tests/test_bbc_ethereum2.py
+++ b/tests/test_bbc_ethereum2.py
@@ -16,6 +16,8 @@ TEST_CONFIG_FILE = 'test_config.json'
 from test_bbc_ethereum_const import TEST_PRIVATE_KEY
 from test_bbc_ethereum_const import TEST_INFURA_PROJECT_ID
 
+TEST_CONTRACT_ADDRESS = '0x31e12b7b5214248184DaBa8071605CE3E92AcDa3'
+
 
 class Args:
 
@@ -92,6 +94,22 @@ def test_setup_deploy(default_config):
 
 
     print("==> BBcAnchor is deployed and tested.")
+
+
+def test_setup_deployed(default_config):
+
+    bbc_ethereum.setup_deployed(default_config, TEST_CONTRACT_ADDRESS)
+
+    prevdir = os.getcwd()
+    os.chdir(bbc1.__path__[0] + '/core/' + bbc_config.DEFAULT_WORKING_DIR)
+
+    f = open(TEST_CONFIG_FILE, 'r')
+    config = json.load(f)
+    f.close()
+
+    assert config['ethereum']['contract_address'] == TEST_CONTRACT_ADDRESS
+
+    print("==> deployed BBcAnchor can be set.")
 
 
 # end of tests/test_bbc_ethereum2.py

--- a/utils/eth_subsystem_tool.py
+++ b/utils/eth_subsystem_tool.py
@@ -72,6 +72,12 @@ class EthereumSubsystemTool(subsystem_tool_lib.SubsystemTool):
         # deploy command
         self.subparsers.add_parser('deploy', help='Deploy the anchor contract')
 
+        # deployed command
+        parser = self.subparsers.add_parser('deployed',
+                help='Use existing anchor contract')
+        parser.add_argument('contract_address', action='store',
+                help='Anchor contract address')
+
         # new_account command
         parser = self.subparsers.add_parser('new_account',
                 help='Create a new Ethereum account')
@@ -148,6 +154,9 @@ if __name__ == '__main__':
 
     elif args.command_type == 'deploy':
         bbc_ethereum.setup_deploy(bbcConfig)
+
+    elif args.command_type == 'deployed':
+        bbc_ethereum.setup_deployed(bbcConfig, args.contract_address)
 
     sys.exit(0)
 


### PR DESCRIPTION
BBcEthereum did not correctly use specified anchor contract address, but used the address for the first instance under the environment, which is fixed.
Added a command for eth_subsystem_tool.py to specify existing contract address to use.
