### PR TITLE
supports Ethereum goerli testnet

### DIFF
--- a/bbc1/core/ethereum/README.md
+++ b/bbc1/core/ethereum/README.md
@@ -1,7 +1,7 @@
 Ledger subsystem with Ethereum for BBc-1
 ===
 Files in this directory supports the ledger subsystem with Ethereum blockchain for BBc-1.
-Currently supports brownie, with infura.io to access to ropsten test network and mainnet of Ethereum.
+Currently supports brownie, with infura.io to access to goerli test network and mainnet of Ethereum.
 
 ## Ledger subsystem
 * **bbc1/core/ethereum/bbc_ethereum.py**
@@ -18,7 +18,7 @@ Currently supports brownie, with infura.io to access to ropsten test network and
 * solc (solidity) 0.5 (install with apt or brew) (actual compilation uses py-solc-x installed with brownie, but requires depedencies for solc anyway)
 
 ## How to use
-For the example below, we assume that BBc-1 Core and the ledger subsystem are pip-installed, and 'bbc_core.py' is running at the user's home directory (the "config.json" file resides under "~/.bbc1"). The default Ethereum network is ropsten test network.
+For the example below, we assume that BBc-1 Core and the ledger subsystem are pip-installed, and 'bbc_core.py' is running at the user's home directory (the "config.json" file resides under "~/.bbc1"). The default Ethereum network is goerli test network.
 
 1. Set up brownie environment
 ```
@@ -33,7 +33,7 @@ If you have already got an account, and know its private key, you can set it usi
 
 3. Load the account with ETH from the specified network
 
-For that, for ropsten, faucets like https://faucet.ropsten.be can be used. The balance can be confirmed with "balance" command of eth_subsystem_tool.py.
+For that, for goerli, faucets like https://goerlifaucet.com can be used. The balance can be confirmed with "balance" command of eth_subsystem_tool.py.
 
 4. Deploy BBcAnchor smart contract
 ```

--- a/bbc1/core/ethereum/README.rst
+++ b/bbc1/core/ethereum/README.rst
@@ -3,7 +3,7 @@ Ledger subsystem with Ethereum for BBc-1
 
 Files in this directory supports the ledger subsystem with Ethereum
 blockchain for BBc-1. Currently supports brownie, with infura.io to
-access to ropsten test network and mainnet of Ethereum.
+access to goerli test network and mainnet of Ethereum.
 
 Ledger subsystem
 ----------------
@@ -40,7 +40,7 @@ How to use
 For the example below, we assume that BBc-1 Core and the ledger
 subsystem are pip-installed, and ‘bbc_core.py’ is running at the user’s
 home directory (the “config.json” file resides under “~/.bbc1”). The
-default Ethereum network is ropsten test network.
+default Ethereum network is goerli test network.
 
 1. Set up brownie environment
 
@@ -59,8 +59,8 @@ set it using “account” command of eth_subsystem_tool.py.
 
 3. Load the account with ETH from the specified network
 
-For that, for ropsten, faucets like https://faucet.ropsten.be can be
-used. The balance can be confirmed with “balance” command of
+For that, for goerli, faucets like https://goerlifaucet.com can be used.
+The balance can be confirmed with “balance” command of
 eth_subsystem_tool.py.
 
 4. Deploy BBcAnchor smart contract

--- a/bbc1/core/ethereum/bbc_ethereum.py
+++ b/bbc1/core/ethereum/bbc_ethereum.py
@@ -92,7 +92,7 @@ def setup_brownie(bbcConfig, infura_project_id):
     Args:
         bbcConfig (BBcConfig): The configuration object.
         infura_project_id (str): INFURA project ID.
-            To be used for setting up 'ropsten' and 'mainnet' networks.
+            To be used for setting up 'goerli' and 'mainnet' networks.
 
     """
     config = bbcConfig.get_config()

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ bbc1_classifiers = [
 
 setup(
     name='ledger_subsystem',
-    version='0.15.1',
+    version='0.16',
     description='A ledger subsystem of Beyond Blockchain One',
     long_description=readme,
     url='https://github.com/beyond-blockchain/ledger_subsystem',

--- a/tests/test_bbc_ethereum1.py
+++ b/tests/test_bbc_ethereum1.py
@@ -30,7 +30,7 @@ class Args:
 def default_config():
     args = Args()
     return bbc_ethereum.setup_config(args.workingdir, args.config,
-            'ropsten' if TEST_INFURA_PROJECT_ID != '' else 'development')
+            'goerli' if TEST_INFURA_PROJECT_ID != '' else 'development')
 
 
 def test_setup_brownie(default_config):

--- a/tests/test_bbc_ethereum2.py
+++ b/tests/test_bbc_ethereum2.py
@@ -16,7 +16,7 @@ TEST_CONFIG_FILE = 'test_config.json'
 from test_bbc_ethereum_const import TEST_PRIVATE_KEY
 from test_bbc_ethereum_const import TEST_INFURA_PROJECT_ID
 
-TEST_CONTRACT_ADDRESS = '0x31e12b7b5214248184DaBa8071605CE3E92AcDa3'
+TEST_CONTRACT_ADDRESS = '0x8c6DB26Ab0eAaDcB46438DDEEE7baD2271e2df71'
 
 
 class Args:
@@ -31,7 +31,7 @@ class Args:
 def default_config():
     args = Args()
     return bbc_ethereum.setup_config(args.workingdir, args.config,
-            'ropsten' if TEST_INFURA_PROJECT_ID != '' else 'development')
+            'goerli' if TEST_INFURA_PROJECT_ID != '' else 'development')
 
 
 def test_setup_account(default_config):

--- a/tests/test_bbc_ethereum3.py
+++ b/tests/test_bbc_ethereum3.py
@@ -29,7 +29,7 @@ class Args:
 def default_config():
     args = Args()
     return bbc_ethereum.setup_config(args.workingdir, args.config,
-            'ropsten' if TEST_INFURA_PROJECT_ID != '' else 'development')
+            'goerli' if TEST_INFURA_PROJECT_ID != '' else 'development')
 
 
 def test_balance(default_config):

--- a/tests/test_bbc_ethereum_const.py
+++ b/tests/test_bbc_ethereum_const.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-# Those who wants to run test_bbc_ethereum[1-2].py on ropsten test network
+# Those who wants to run test_bbc_ethereum[1-2].py on goerli test network
 # needs to define the following, and to load the account with an appropriate
-# amount of ropsten ETH.
-TEST_PRIVATE_KEY = ''
-TEST_INFURA_PROJECT_ID = ''
+# amount of goerli ETH.
+TEST_PRIVATE_KEY = '0xe65b5fda980d5deb87a2655c66d78bae5b212658946103882e806ee3234ada31'
+TEST_INFURA_PROJECT_ID = '64ac8922d8d6432d8bbaa3af8a98d1f1'
 
 # end of test_bbc_ethereum_const.py

--- a/tests/test_bbc_ethereum_const.py
+++ b/tests/test_bbc_ethereum_const.py
@@ -3,7 +3,7 @@
 # Those who wants to run test_bbc_ethereum[1-2].py on goerli test network
 # needs to define the following, and to load the account with an appropriate
 # amount of goerli ETH.
-TEST_PRIVATE_KEY = '0xe65b5fda980d5deb87a2655c66d78bae5b212658946103882e806ee3234ada31'
-TEST_INFURA_PROJECT_ID = '64ac8922d8d6432d8bbaa3af8a98d1f1'
+TEST_PRIVATE_KEY = ''
+TEST_INFURA_PROJECT_ID = ''
 
 # end of test_bbc_ethereum_const.py

--- a/utils/eth_subsystem_tool.py
+++ b/utils/eth_subsystem_tool.py
@@ -49,8 +49,8 @@ class EthereumSubsystemTool(subsystem_tool_lib.SubsystemTool):
 
     def _add_additional_arguments(self):
         self.argparser.add_argument('-n', '--network', type=str,
-                default='ropsten',
-                help='network name (ropsten by default)')
+                default='goerli',
+                help='network name (goerli by default)')
 
         # account command
         parser = self.subparsers.add_parser('account',


### PR DESCRIPTION
- Default testnet to be used is now goerli instead of ropsten to be discontinued.
